### PR TITLE
Update swiftDocC.yml

### DIFF
--- a/.github/workflows/swiftDocC.yml
+++ b/.github/workflows/swiftDocC.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
     steps:
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@v2
     - name: Get swift version
       run: |
         swift --version # Swift 5.8


### PR DESCRIPTION
Node.js 16のアクションは非推奨です。以下のアクションをNode.js 20に更新してください: swift-actions/setup-swift@v1. 詳細はhttps://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

のエラー対応